### PR TITLE
Feat/#8: 비밀번호 재설정 기능 추가

### DIFF
--- a/src/main/java/com/multicampus/gamesungcoding/a11ymarketserver/auth/controller/AuthController.java
+++ b/src/main/java/com/multicampus/gamesungcoding/a11ymarketserver/auth/controller/AuthController.java
@@ -9,6 +9,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Map;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
@@ -60,5 +62,32 @@ public class AuthController {
         return ResponseEntity.status(HttpStatus.CREATED).body(resp);
     }
 
+    @PostMapping("/auth/password/request-reset")
+    public ResponseEntity<Object> requestResetPwd(@RequestBody @Valid PwdResetReqDTO dto) {
+        boolean ok = authService.requestResetPwd(dto);
+
+        if (!ok) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(Map.of("msg", "사용자 정보가 일치하지 않습니다."));
+        }
+
+        return ResponseEntity.ok(
+                Map.of("msg", "비밀번호 재설정 요청 완료. 이메일을 확인해주세요.")
+        );
+    }
+
+    @PostMapping("/auth/password/request-confirm")
+    public ResponseEntity<Object> confirmResetPwd(@RequestBody @Valid PwdResetConfirmDTO dto) {
+        boolean ok = authService.confirmResetPwd(dto);
+
+        if (!ok) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(Map.of("msg", "토큰이 유효하지 않거나 만료되었습니다."));
+        }
+
+        return ResponseEntity.ok(
+                Map.of("msg", "비밀번호가 성공적으로 변경되었습니다.")
+        );
+    }
 }
 

--- a/src/main/java/com/multicampus/gamesungcoding/a11ymarketserver/auth/dto/PwdResetConfirmDTO.java
+++ b/src/main/java/com/multicampus/gamesungcoding/a11ymarketserver/auth/dto/PwdResetConfirmDTO.java
@@ -10,7 +10,7 @@ import java.util.UUID;
 
 @Getter
 @Setter
-public class PwdResetConfirmDTO {
+public class PwdResetConfirmDTO { // rebase 과정에서 누락된 비밀번호 재설정 DTO 복구
 
     @NotBlank(message = "사용자 ID는 필수입니다.")
     private UUID userId;

--- a/src/main/java/com/multicampus/gamesungcoding/a11ymarketserver/auth/dto/PwdResetReqDTO.java
+++ b/src/main/java/com/multicampus/gamesungcoding/a11ymarketserver/auth/dto/PwdResetReqDTO.java
@@ -5,12 +5,14 @@ import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.util.UUID;
+
 @Getter
 @Setter
 public class PwdResetReqDTO {
 
     @NotBlank(message = "사용자 ID는 필수입니다.")
-    private String userId;
+    private UUID userId;
 
     @NotBlank(message = "이메일은 필수입니다.")
     @Email(message = "유효한 이메일을 입력해주세요.")

--- a/src/main/java/com/multicampus/gamesungcoding/a11ymarketserver/user/model/Users.java
+++ b/src/main/java/com/multicampus/gamesungcoding/a11ymarketserver/user/model/Users.java
@@ -48,6 +48,13 @@ public class Users {
     @Column(nullable = false)
     private LocalDateTime updatedAt;
 
+
+    /*
+    db에 다음 두 줄을 추가했습니다.
+    ALTER TABLE USERS ADD reset_token VARCHAR2(20);
+    ALTER TABLE USERS ADD reset_token_expire_at TIMESTAMP;
+     */
+
     //비밀번호 재설정 관련
     @Column(length = 20)
     @Setter


### PR DESCRIPTION
## PR 내용

-비밀번호 재설정 기능 추가

## 연관 이슈

Resolves #4 


## 변경 사항

- [x] AuthController에 비밀번호 재설정 요청/확인 api 추가
- [x] AuthService에 토큰 생성 메소드, 비밀번호 재설정 요청/확인  메소드 추가
- [x] PwdResetReqDTO 추가
- [x] PwdResetConfirmDTO 추가
- [x] user.model.Users에 resetToken, resetTokenExpireAt 컬럼 추가

## 리뷰 요구사항(Optional)

db의 user에 resetToken과 resetTokenExpireAt 컬럼을 추가했습니다. 
db에 
ALTER TABLE USERS ADD reset_token VARCHAR2(20);
ALTER TABLE USERS ADD reset_token_expire_at TIMESTAMP;
를 쓰시고 정상적으로 작동하는지 확인 부탁드립니다.
