### PR TITLE
Feat/#59: 관리자 주문내역 전체 조회 기능 추가

### DIFF
--- a/src/main/java/com/multicampus/gamesungcoding/a11ymarketserver/admin/order/controller/AdminOrderManageController.java
+++ b/src/main/java/com/multicampus/gamesungcoding/a11ymarketserver/admin/order/controller/AdminOrderManageController.java
@@ -1,22 +1,29 @@
 package com.multicampus.gamesungcoding.a11ymarketserver.admin.order.controller;
 
+import com.multicampus.gamesungcoding.a11ymarketserver.admin.order.model.AdminOrderRespDTO;
+import com.multicampus.gamesungcoding.a11ymarketserver.admin.order.service.AdminOrderService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
 public class AdminOrderManageController {
-    // 관리자 - 전체 주문 조회 (미구현)
+
+    private final AdminOrderService adminOrderService;
+
+    // 관리자 - 전체 주문 조회
     @GetMapping("/v1/admin/orders")
-    public ResponseEntity<String> inquireAllOrders() {
+    public ResponseEntity<List<AdminOrderRespDTO>> inquireAllOrders() {
         log.info("AdminUserManageController - inquireAllOrders");
 
-        // Placeholder for future implementation
-        return ResponseEntity.ok("All orders inquiry functionality is under development.");
+        List<AdminOrderRespDTO> orders = adminOrderService.getAllOrders();
+        return ResponseEntity.ok(orders);
     }
 
     // 관리자 - 특정 주문 조회 (미구현)

--- a/src/main/java/com/multicampus/gamesungcoding/a11ymarketserver/admin/order/model/AdminOrderRespDTO.java
+++ b/src/main/java/com/multicampus/gamesungcoding/a11ymarketserver/admin/order/model/AdminOrderRespDTO.java
@@ -1,0 +1,26 @@
+package com.multicampus.gamesungcoding.a11ymarketserver.admin.order.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Data
+@AllArgsConstructor
+public class AdminOrderRespDTO {
+    private UUID orderId;
+    private String userName;
+    private String userEmail;
+    private String userPhone;
+    private String receiverName;
+    private String receiverPhone;
+    private String receiverZipcode;
+    private String receiverAddr1;
+    private String receiverAddr2;
+    private String orderStatus;
+    private Integer totalPrice;
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/multicampus/gamesungcoding/a11ymarketserver/admin/order/model/Orders.java
+++ b/src/main/java/com/multicampus/gamesungcoding/a11ymarketserver/admin/order/model/Orders.java
@@ -1,0 +1,62 @@
+package com.multicampus.gamesungcoding.a11ymarketserver.admin.order.model;
+
+import com.multicampus.gamesungcoding.a11ymarketserver.config.id.UuidV7;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "orders")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@EntityListeners(AuditingEntityListener.class)
+public class Orders {
+
+    @Id
+    @UuidV7  // 커스텀 UUID v7 생성
+    @Column(length = 16, updatable = false, nullable = false)
+    private UUID orderId;
+
+    @Column(length = 30)
+    private String userName;
+
+    @Column(length = 254)
+    private String userEmail;
+
+    @Column(length = 15)
+    private String userPhone;
+
+    @Column(length = 30)
+    private String receiverName;
+
+    @Column(length = 15)
+    private String receiverPhone;
+
+    @Column(columnDefinition = "CHAR(5)")
+    private String receiverZipcode;
+
+    @Column(length = 100)
+    private String receiverAddr1;
+
+    @Column(length = 200)
+    private String receiverAddr2;
+
+    @Column(length = 30)
+    private String orderStatus;
+
+    @Column
+    private Integer totalPrice;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/multicampus/gamesungcoding/a11ymarketserver/admin/order/repository/AdminOrderRepository.java
+++ b/src/main/java/com/multicampus/gamesungcoding/a11ymarketserver/admin/order/repository/AdminOrderRepository.java
@@ -1,0 +1,11 @@
+package com.multicampus.gamesungcoding.a11ymarketserver.admin.order.repository;
+
+import com.multicampus.gamesungcoding.a11ymarketserver.admin.order.model.Orders;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface AdminOrderRepository extends JpaRepository<Orders, UUID> {
+}

--- a/src/main/java/com/multicampus/gamesungcoding/a11ymarketserver/admin/order/service/AdminOrderService.java
+++ b/src/main/java/com/multicampus/gamesungcoding/a11ymarketserver/admin/order/service/AdminOrderService.java
@@ -1,0 +1,36 @@
+package com.multicampus.gamesungcoding.a11ymarketserver.admin.order.service;
+
+import com.multicampus.gamesungcoding.a11ymarketserver.admin.order.model.AdminOrderRespDTO;
+import com.multicampus.gamesungcoding.a11ymarketserver.admin.order.repository.AdminOrderRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class AdminOrderService {
+
+    private final AdminOrderRepository ordersRepository;
+
+    public List<AdminOrderRespDTO> getAllOrders() {
+        return ordersRepository.findAll()
+                .stream()
+                .map(order -> new AdminOrderRespDTO(
+                        order.getOrderId(),
+                        order.getUserName(),
+                        order.getUserEmail(),
+                        order.getUserPhone(),
+                        order.getReceiverName(),
+                        order.getReceiverPhone(),
+                        order.getReceiverZipcode(),
+                        order.getReceiverAddr1(),
+                        order.getReceiverAddr2(),
+                        order.getOrderStatus(),
+                        order.getTotalPrice(),
+                        order.getCreatedAt()
+                ))
+                .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
## PR 내용

- 관리자 주문내역 전체 조회 기능 구현 완료

## 연관 이슈

Resolves #59

## 변경 사항

- [x] @GetMapping("/v1/admin/orders") inquireAllOrders() 수정 - 구현완료
- [x] AdminOrderRepository, AdminOrderRespDTO, AdminOrderService, Orders 추가

## 리뷰 요구사항(Optional)

- 테스트 완료했습니다
