### PR TITLE
Feat/#50: 받은 주문 목록 조회

### DIFF
--- a/src/main/java/com/multicampus/gamesungcoding/a11ymarketserver/feature/order/repository/OrderItemsRepository.java
+++ b/src/main/java/com/multicampus/gamesungcoding/a11ymarketserver/feature/order/repository/OrderItemsRepository.java
@@ -2,14 +2,28 @@ package com.multicampus.gamesungcoding.a11ymarketserver.feature.order.repository
 
 import com.multicampus.gamesungcoding.a11ymarketserver.feature.order.entity.OrderItemStatus;
 import com.multicampus.gamesungcoding.a11ymarketserver.feature.order.entity.OrderItems;
+import com.multicampus.gamesungcoding.a11ymarketserver.feature.seller.model.SellerOrderItemResponse;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.UUID;
 
 public interface OrderItemsRepository extends JpaRepository<OrderItems, UUID> {
 
-    List<OrderItems> findByProductIdIn(List<UUID> productIds);
-
-    List<OrderItems> findByProductIdInAndOrderItemStatus(List<UUID> productIds, OrderItemStatus status);
+    @Query("""
+            SELECT new com.multicampus.gamesungcoding.a11ymarketserver.feature.seller.model.SellerOrderItemResponse(o, oi)
+              FROM OrderItems oi, Orders o, Product p, Seller s, Users u
+             WHERE oi.orderId = o.orderId
+               AND oi.productId = p.productId
+               AND p.sellerId = s.sellerId
+               AND s.userId = u.userId
+               AND u.userEmail = :userEmail
+               AND (:status IS NULL OR oi.orderItemStatus = :status)
+            """)
+    List<SellerOrderItemResponse> findSellerReceivedOrders(
+            @Param("userEmail") String userEmail,
+            @Param("status") OrderItemStatus status
+    );
 }

--- a/src/main/java/com/multicampus/gamesungcoding/a11ymarketserver/feature/seller/controller/SellerController.java
+++ b/src/main/java/com/multicampus/gamesungcoding/a11ymarketserver/feature/seller/controller/SellerController.java
@@ -86,9 +86,10 @@ public class SellerController {
     @GetMapping("/v1/seller/orders")
     public ResponseEntity<List<SellerOrderItemResponse>> getReceivedOrders(
             @AuthenticationPrincipal UserDetails userDetails,
-            @RequestParam(required = false) String status
-    ) {
-        var responses = sellerService.getReceivedOrders(userDetails.getUsername(), status);
+            @RequestParam(required = false) String status) {
+
+        List<SellerOrderItemResponse> responses = sellerService.getReceivedOrders(userDetails.getUsername(), status);
+
         return ResponseEntity.ok(responses);
     }
 }

--- a/src/main/java/com/multicampus/gamesungcoding/a11ymarketserver/feature/seller/model/SellerOrderItemResponse.java
+++ b/src/main/java/com/multicampus/gamesungcoding/a11ymarketserver/feature/seller/model/SellerOrderItemResponse.java
@@ -20,10 +20,10 @@ public record SellerOrderItemResponse(
         String buyerPhone,
         LocalDateTime orderedAt
 ) {
-    public static SellerOrderItemResponse of(Orders order, OrderItems item) {
-        return new SellerOrderItemResponse(
+    public SellerOrderItemResponse(Orders order, OrderItems item) {
+        this(
                 item.getOrderItemId(),
-                item.getOrderId(),
+                order.getOrderId(),
                 item.getProductId(),
                 item.getProductName(),
                 item.getProductPrice(),

--- a/src/main/java/com/multicampus/gamesungcoding/a11ymarketserver/feature/seller/service/SellerService.java
+++ b/src/main/java/com/multicampus/gamesungcoding/a11ymarketserver/feature/seller/service/SellerService.java
@@ -5,10 +5,7 @@ import com.multicampus.gamesungcoding.a11ymarketserver.common.exception.DataNotF
 import com.multicampus.gamesungcoding.a11ymarketserver.common.exception.InvalidRequestException;
 import com.multicampus.gamesungcoding.a11ymarketserver.common.exception.UserNotFoundException;
 import com.multicampus.gamesungcoding.a11ymarketserver.feature.order.entity.OrderItemStatus;
-import com.multicampus.gamesungcoding.a11ymarketserver.feature.order.entity.OrderItems;
-import com.multicampus.gamesungcoding.a11ymarketserver.feature.order.entity.Orders;
 import com.multicampus.gamesungcoding.a11ymarketserver.feature.order.repository.OrderItemsRepository;
-import com.multicampus.gamesungcoding.a11ymarketserver.feature.order.repository.OrdersRepository;
 import com.multicampus.gamesungcoding.a11ymarketserver.feature.product.model.Product;
 import com.multicampus.gamesungcoding.a11ymarketserver.feature.product.model.ProductDTO;
 import com.multicampus.gamesungcoding.a11ymarketserver.feature.product.model.ProductStatus;
@@ -23,7 +20,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -33,7 +29,6 @@ public class SellerService {
     private final SellerRepository sellerRepository;
     private final ProductRepository productRepository;
     private final UserRepository userRepository;
-    private final OrdersRepository ordersRepository;
     private final OrderItemsRepository orderItemsRepository;
 
     public SellerApplyResponse applySeller(String userEmail, SellerApplyRequest request) {
@@ -180,57 +175,23 @@ public class SellerService {
 
     @Transactional(readOnly = true)
     public List<SellerOrderItemResponse> getReceivedOrders(String userEmail, String status) {
-        var seller = sellerRepository.findByUserEmail(userEmail)
+
+        Seller seller = sellerRepository.findByUserEmail(userEmail)
                 .orElseThrow(() -> new DataNotFoundException("판매자 정보를 찾을 수 없습니다."));
 
         if (!SellerSubmitStatus.APPROVED.getStatus().equals(seller.getSellerSubmitStatus())) {
             throw new InvalidRequestException("승인된 판매자만 주문 목록을 조회할 수 있습니다.");
         }
 
-        var sellerId = seller.getSellerId();
-
-        var products = productRepository.findBySellerId(sellerId);
-        if (products.isEmpty()) {
-            return List.of();
-        }
-
-        var productIds = products.stream()
-                .map(com.multicampus.gamesungcoding.a11ymarketserver.feature.product.model.Product::getProductId)
-                .toList();
-
-        List<OrderItems> orderItems;
-        if (status == null || status.isBlank()) {
-            orderItems = orderItemsRepository.findByProductIdIn(productIds);
-        } else {
-            OrderItemStatus itemStatus;
+        OrderItemStatus statusFilter = null;
+        if (status != null && !status.isBlank()) {
             try {
-                itemStatus = OrderItemStatus.valueOf(status.toUpperCase());
+                statusFilter = OrderItemStatus.valueOf(status.toUpperCase());
             } catch (IllegalArgumentException e) {
                 throw new InvalidRequestException("유효하지 않은 주문 상태입니다.");
             }
-            orderItems = orderItemsRepository.findByProductIdInAndOrderItemStatus(productIds, itemStatus);
         }
-
-        if (orderItems.isEmpty()) {
-            return List.of();
-        }
-
-        var orderIds = orderItems.stream()
-                .map(OrderItems::getOrderId)
-                .distinct()
-                .toList();
-
-        var ordersMap = ordersRepository.findAllById(orderIds).stream()
-                .collect(Collectors.toMap(Orders::getOrderId, o -> o));
-
-        return orderItems.stream()
-                .map(item -> {
-                    var order = ordersMap.get(item.getOrderId());
-                    if (order == null) {
-                        throw new DataNotFoundException("주문 정보를 찾을 수 없습니다.");
-                    }
-                    return SellerOrderItemResponse.of(order, item);
-                })
-                .toList();
+        
+        return orderItemsRepository.findSellerReceivedOrders(userEmail, statusFilter);
     }
 }


### PR DESCRIPTION
## PR 내용

- 받은 주문 목록 조회 기능 추가

## 연관 이슈

Resolves #50 
## 변경 사항

- [x] OrderItemsRepository
ㄴ 주문 상품 조회를 위한 Repository 추가
ㄴ 판매자가 등록한 상품 목록의 `productId` 들을 기준으로 `OrderItems` 조회

- [x] SellerOrderItemResponse (신규 DTO)
ㄴ 판매자 전용 "받은 주문" 응답 DTO 추가

- [x] SellerService
ㄴ `getReceivedOrders(String userEmail)` 메서드 추가

- [x] SellerController
ㄴ 받은 주문 목록 조회 엔드포인트 추가

## 리뷰 요구사항(Optional)

전체적으로 검토 및 어색하거나 맞지 않는 코드가 있으면 수정 요청 부탁드립니다.
