### PR TITLE
Feat/#42: 주문 상태 변경

### DIFF
--- a/src/main/java/com/multicampus/gamesungcoding/a11ymarketserver/feature/order/entity/Orders.java
+++ b/src/main/java/com/multicampus/gamesungcoding/a11ymarketserver/feature/order/entity/Orders.java
@@ -82,8 +82,11 @@ public class Orders {
         this.orderStatus = orderStatus;
     }
 
-
     public void updateTotalPrice(int totalPrice) {
         this.totalPrice = totalPrice;
+    }
+
+    public void updateOrderStatus(OrderStatus orderStatus) {
+        this.orderStatus = orderStatus;
     }
 }

--- a/src/main/java/com/multicampus/gamesungcoding/a11ymarketserver/feature/order/repository/OrderItemsRepository.java
+++ b/src/main/java/com/multicampus/gamesungcoding/a11ymarketserver/feature/order/repository/OrderItemsRepository.java
@@ -26,6 +26,7 @@ public interface OrderItemsRepository extends JpaRepository<OrderItems, UUID> {
             """)
     List<SellerOrderItemResponse> findSellerReceivedOrders(
             @Param("userEmail") String userEmail,
-            @Param("status") OrderItemStatus status
-    );
+            @Param("status") OrderItemStatus status);
+
+    boolean existsByOrderIdAndProductIdIn(UUID orderId, List<UUID> productIds);
 }

--- a/src/main/java/com/multicampus/gamesungcoding/a11ymarketserver/feature/seller/controller/SellerController.java
+++ b/src/main/java/com/multicampus/gamesungcoding/a11ymarketserver/feature/seller/controller/SellerController.java
@@ -89,7 +89,17 @@ public class SellerController {
             @RequestParam(required = false) String status) {
 
         List<SellerOrderItemResponse> responses = sellerService.getReceivedOrders(userDetails.getUsername(), status);
-
         return ResponseEntity.ok(responses);
+    }
+
+    @PatchMapping("/v1/seller/orders/{orderId}/status")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public ResponseEntity<Void> updateOrderStatus(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable String orderId,
+            @RequestBody @Valid SellerOrderStatusUpdateRequest request) {
+
+        sellerService.updateOrderStatus(userDetails.getUsername(), UUID.fromString(orderId), request);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/multicampus/gamesungcoding/a11ymarketserver/feature/seller/model/SellerOrderStatusUpdateRequest.java
+++ b/src/main/java/com/multicampus/gamesungcoding/a11ymarketserver/feature/seller/model/SellerOrderStatusUpdateRequest.java
@@ -1,0 +1,8 @@
+package com.multicampus.gamesungcoding.a11ymarketserver.feature.seller.model;
+
+import com.multicampus.gamesungcoding.a11ymarketserver.feature.order.entity.OrderStatus;
+import jakarta.validation.constraints.NotNull;
+
+public record SellerOrderStatusUpdateRequest(
+        @NotNull OrderStatus status) {
+}


### PR DESCRIPTION
## PR 내용

- 주문 상태 변경 기능 추가

## 연관 이슈

Resolves #42

## 변경 사항

- [x] SellerController
ㄴ 주문 상태 변경 API 추가

- [x] SellerService
ㄴ 판매자 주문 상태 변경 로직 구현
ㄴ 주문 상태 전이 검증 메서드 추가 -> validateSellerOrderStatusTransition 도입
ㄴ PAID → ACCEPTED/REJECTED, ACCEPTED → SHIPPED, SHIPPED → DELIVERED만 허용
ㄴ 비정상적인 상태 변경 차단 및 보안 강화

- [x] SellerOrderStatusUpdateRequest DTO
ㄴ 주문 상태 변경 요청 전용 DTO 추가 (OrderStatus 기반)

- [x] Orders 엔티티 updateOrderStatus 메서드
ㄴ 주문 상태 변경 전용 도메인 메서드 구현

- [x] OrderStatus
ㄴ enum 값을 사용하여 상태 변경을 일관성 있게 관리

## 리뷰 요구사항(Optional)
전체적으로 검토 및 어색하거나 맞지 않는 코드가 있으면 수정 요청 부탁드립니다.
