### PR TITLE
Feat/#54: 판매자 가입 승인 대기 목록 조회 기능 추가

### DIFF
--- a/src/main/java/com/multicampus/gamesungcoding/a11ymarketserver/admin/seller/controller/AdminSellerManageController.java
+++ b/src/main/java/com/multicampus/gamesungcoding/a11ymarketserver/admin/seller/controller/AdminSellerManageController.java
@@ -1,9 +1,13 @@
 package com.multicampus.gamesungcoding.a11ymarketserver.admin.seller.controller;
 
+import com.multicampus.gamesungcoding.a11ymarketserver.admin.seller.service.AdminSellerService;
+import com.multicampus.gamesungcoding.a11ymarketserver.feature.seller.model.SellerApplyResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Slf4j
 @RestController
@@ -11,13 +15,15 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api")
 public class AdminSellerManageController {
 
-    // 관리자 - 판매자 승인 대기 목록 조회 (미구현)
-    @GetMapping("/v1/admin/sellers/pending")
-    public ResponseEntity<String> inquirePendingSellers() {
-        log.info("AdminUserManageController - inquirePendingSellers");
+    private final AdminSellerService adminSellerService;
 
-        // Placeholder for future implementation
-        return ResponseEntity.ok("Pending sellers inquiry functionality is under development.");
+    // 관리자 - 판매자 승인 대기 목록 조회
+    @GetMapping("/v1/admin/sellers/pending")
+    public ResponseEntity<List<SellerApplyResponse>> inquirePendingSellers() {
+
+        List<SellerApplyResponse> pendingSellers = adminSellerService.inquirePendingSellers();
+
+        return ResponseEntity.ok(pendingSellers);
     }
 
     // 관리자 - 판매자 상태 변경 (미구현)

--- a/src/main/java/com/multicampus/gamesungcoding/a11ymarketserver/admin/seller/service/AdminSellerService.java
+++ b/src/main/java/com/multicampus/gamesungcoding/a11ymarketserver/admin/seller/service/AdminSellerService.java
@@ -1,0 +1,31 @@
+package com.multicampus.gamesungcoding.a11ymarketserver.admin.seller.service;
+
+import com.multicampus.gamesungcoding.a11ymarketserver.feature.seller.model.Seller;
+import com.multicampus.gamesungcoding.a11ymarketserver.feature.seller.model.SellerApplyResponse;
+import com.multicampus.gamesungcoding.a11ymarketserver.feature.seller.model.SellerSubmitStatus;
+import com.multicampus.gamesungcoding.a11ymarketserver.feature.seller.repository.SellerRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminSellerService {
+
+    private final SellerRepository sellerRepository;
+
+    public List<SellerApplyResponse> inquirePendingSellers() {
+
+        List<Seller> pendingList = sellerRepository.findBySellerSubmitStatus(SellerSubmitStatus.PENDING.getStatus());
+
+        return pendingList.stream()
+                .map(SellerApplyResponse::fromEntity)
+                .toList();
+    }
+
+}

--- a/src/main/java/com/multicampus/gamesungcoding/a11ymarketserver/feature/seller/model/SellerApplyResponse.java
+++ b/src/main/java/com/multicampus/gamesungcoding/a11ymarketserver/feature/seller/model/SellerApplyResponse.java
@@ -13,4 +13,19 @@ public record SellerApplyResponse(
         String sellerSubmitStatus,
         LocalDateTime submitDate,
         LocalDateTime approvedDate) {
+
+    public static SellerApplyResponse fromEntity(Seller seller) {
+        return new SellerApplyResponse(
+                seller.getSellerId(),
+                seller.getSellerName(),
+                seller.getBusinessNumber(),
+                seller.getSellerGrade(),
+                seller.getSellerIntro(),
+                seller.getA11yGuarantee(),
+                seller.getSellerSubmitStatus(),
+                seller.getSubmitDate(),
+                seller.getApprovedDate()
+        );
+    }
+
 }

--- a/src/main/java/com/multicampus/gamesungcoding/a11ymarketserver/feature/seller/repository/SellerRepository.java
+++ b/src/main/java/com/multicampus/gamesungcoding/a11ymarketserver/feature/seller/repository/SellerRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -20,4 +21,7 @@ public interface SellerRepository extends JpaRepository<Seller, UUID> {
                     )
             """)
     Optional<Seller> findByUserEmail(@Param("email") String userEmail);
+
+    // sellerSubmitStatus가 pending인 만매자 조회
+    List<Seller> findBySellerSubmitStatus(String status);
 }


### PR DESCRIPTION
## PR 내용

- 판매자 가입 승인 대기 목록 조회 기능 추가

## 연관 이슈

Resolves #54

## 변경 사항

- [x] Implement AdminSellerService with inquirePendingSellers
- [x] Add SellerApplyResponse DTO with fromEntity
- [x] Add SellerRepository with findBySellerSubmitStatus
- [x] Add AdminSellerManageController with inquirePendingSellers

## 리뷰 요구사항(Optional)

- 현재 sellers entity의 seller_submit_status를 string 타입이라  string으로 개발했습니다. 추후 전반적으로 Enum으로 수정해서 관리해야할 것 같습니다.
