### PR TITLE
Feat/#20 #21 Add myPage orders list & detail API

### DIFF
--- a/src/main/java/com/multicampus/gamesungcoding/a11ymarketserver/feature/order/controller/OrderController.java
+++ b/src/main/java/com/multicampus/gamesungcoding/a11ymarketserver/feature/order/controller/OrderController.java
@@ -1,9 +1,6 @@
 package com.multicampus.gamesungcoding.a11ymarketserver.feature.order.controller;
 
-import com.multicampus.gamesungcoding.a11ymarketserver.feature.order.dto.OrderCheckRequest;
-import com.multicampus.gamesungcoding.a11ymarketserver.feature.order.dto.OrderCheckoutResponse;
-import com.multicampus.gamesungcoding.a11ymarketserver.feature.order.dto.OrderCreateRequest;
-import com.multicampus.gamesungcoding.a11ymarketserver.feature.order.dto.OrderResponse;
+import com.multicampus.gamesungcoding.a11ymarketserver.feature.order.dto.*;
 import com.multicampus.gamesungcoding.a11ymarketserver.feature.order.service.OrderService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -12,12 +9,11 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
+import java.util.List;
+import java.util.UUID;
 
 @Slf4j
 @RestController
@@ -33,7 +29,7 @@ public class OrderController {
     public OrderCheckoutResponse preCheck(
             @AuthenticationPrincipal UserDetails userDetails,
             @Valid @RequestBody OrderCheckRequest req) {
-        
+
         return orderService.getCheckoutInfo(userDetails.getUsername(), req);
     }
 
@@ -47,5 +43,26 @@ public class OrderController {
         return ResponseEntity
                 .created(URI.create("/api/v1/users/me/orders/" + orderResp.orderId()))
                 .body(orderResp);
+    }
+
+    // 내 주문 목록 조회
+    @GetMapping("/v1/users/me/orders")
+    public ResponseEntity<List<OrderResponse>> getMyOrders(
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        return ResponseEntity.ok(
+                orderService.getMyOrders(userDetails.getUsername())
+        );
+    }
+
+    // 내 주문 상세 조회
+    @GetMapping("/v1/users/me/orders/{orderId}")
+    public ResponseEntity<OrderDetailResponse> getMyOrderDetail(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable UUID orderId
+    ) {
+        return ResponseEntity.ok(
+                orderService.getMyOrderDetail(orderId, userDetails.getUsername())
+        );
     }
 }

--- a/src/main/java/com/multicampus/gamesungcoding/a11ymarketserver/feature/order/repository/OrdersRepository.java
+++ b/src/main/java/com/multicampus/gamesungcoding/a11ymarketserver/feature/order/repository/OrdersRepository.java
@@ -3,7 +3,15 @@ package com.multicampus.gamesungcoding.a11ymarketserver.feature.order.repository
 import com.multicampus.gamesungcoding.a11ymarketserver.feature.order.entity.Orders;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface OrdersRepository extends JpaRepository<Orders, UUID> {
+
+    // 내 주문 목록
+    List<Orders> findAllByUserEmailOrderByCreatedAtDesc(String userEmail);
+
+    //내 주문 상세
+    Optional<Orders> findByOrderIdAndUserEmail(UUID orderId, String userEmail);
 }

--- a/src/main/java/com/multicampus/gamesungcoding/a11ymarketserver/feature/order/service/OrderService.java
+++ b/src/main/java/com/multicampus/gamesungcoding/a11ymarketserver/feature/order/service/OrderService.java
@@ -9,10 +9,7 @@ import com.multicampus.gamesungcoding.a11ymarketserver.feature.cart.entity.Cart;
 import com.multicampus.gamesungcoding.a11ymarketserver.feature.cart.entity.CartItems;
 import com.multicampus.gamesungcoding.a11ymarketserver.feature.cart.repository.CartItemRepository;
 import com.multicampus.gamesungcoding.a11ymarketserver.feature.cart.repository.CartRepository;
-import com.multicampus.gamesungcoding.a11ymarketserver.feature.order.dto.OrderCheckRequest;
-import com.multicampus.gamesungcoding.a11ymarketserver.feature.order.dto.OrderCheckoutResponse;
-import com.multicampus.gamesungcoding.a11ymarketserver.feature.order.dto.OrderCreateRequest;
-import com.multicampus.gamesungcoding.a11ymarketserver.feature.order.dto.OrderResponse;
+import com.multicampus.gamesungcoding.a11ymarketserver.feature.order.dto.*;
 import com.multicampus.gamesungcoding.a11ymarketserver.feature.order.entity.*;
 import com.multicampus.gamesungcoding.a11ymarketserver.feature.order.repository.OrderItemsRepository;
 import com.multicampus.gamesungcoding.a11ymarketserver.feature.order.repository.OrdersRepository;
@@ -157,5 +154,30 @@ public class OrderService {
         }
 
         return cartItems;
+    }
+
+    // 내 주문 목록 조회
+    @Transactional(readOnly = true)
+    public List<OrderResponse> getMyOrders(String userEmail) {
+        return ordersRepository
+                .findAllByUserEmailOrderByCreatedAtDesc(userEmail)
+                .stream()
+                .map(OrderResponse::fromEntity)
+                .toList();
+    }
+
+    // 내 주문 상세 조회
+    @Transactional(readOnly = true)
+    public OrderDetailResponse getMyOrderDetail(UUID orderId, String userEmail) {
+        Orders order = ordersRepository
+                .findByOrderIdAndUserEmail(orderId, userEmail)
+                .orElseThrow(() -> new DataNotFoundException("주문을 찾을 수 없습니다."));
+
+        List<OrderItems> items = orderItemsRepository.findByOrderId(order.getOrderId());
+
+        if (items.isEmpty()) {
+            throw new DataNotFoundException("주문 아이템이 없습니다.");
+        }
+        return OrderDetailResponse.fromEntity(order, items);
     }
 }


### PR DESCRIPTION
## PR 내용
- 마이페이지 내 주문 목록 / 상세 조회 API 구현

## 연관 이슈
Resolves #20 #21 

## 변경 사항

- [x] 내 주문 목록 조회 (GET /api/v1/users/me/orders) 추가
- [x] 내 주문 상세 조회 (GET /api/v1/users/me/orders/{orderId) 추가
- [x] OrderService에 getMyOrders(), getMyOrderDetail() 추가
- [x] OrdersRepository 변경

