### PR TITLE
Feat/#44: 주문 취소/반품/교환 접수

### DIFF
--- a/src/main/java/com/multicampus/gamesungcoding/a11ymarketserver/feature/order/entity/OrderItems.java
+++ b/src/main/java/com/multicampus/gamesungcoding/a11ymarketserver/feature/order/entity/OrderItems.java
@@ -64,4 +64,8 @@ public class OrderItems {
         this.orderItemStatus = OrderItemStatus.CANCELED;
         this.cancelReason = reason;
     }
+
+    public void updateOrderItemStatus(OrderItemStatus status) {
+        this.orderItemStatus = status;
+    }
 }

--- a/src/main/java/com/multicampus/gamesungcoding/a11ymarketserver/feature/seller/controller/SellerController.java
+++ b/src/main/java/com/multicampus/gamesungcoding/a11ymarketserver/feature/seller/controller/SellerController.java
@@ -42,7 +42,6 @@ public class SellerController {
     }
 
     @GetMapping("/v1/seller/products")
-    @ResponseStatus(HttpStatus.OK)
     public ResponseEntity<List<ProductDTO>> getMyProducts(
             @AuthenticationPrincipal UserDetails userDetails) {
 
@@ -52,7 +51,6 @@ public class SellerController {
 
 
     @PutMapping("/v1/seller/products/{productId}")
-    @ResponseStatus(HttpStatus.OK)
     public ResponseEntity<ProductDTO> updateProduct(
             @AuthenticationPrincipal UserDetails userDetails,
             @PathVariable String productId,
@@ -73,7 +71,6 @@ public class SellerController {
     }
 
     @PatchMapping("/v1/seller/products/{productId}/stock")
-    @ResponseStatus(HttpStatus.OK)
     public ResponseEntity<ProductDTO> updateProductStock(
             @AuthenticationPrincipal UserDetails userDetails,
             @PathVariable String productId,
@@ -101,5 +98,15 @@ public class SellerController {
 
         sellerService.updateOrderStatus(userDetails.getUsername(), UUID.fromString(orderId), request);
         return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/v1/seller/claims/{claimId}/approve")
+    public ResponseEntity<Void> processOrderClaim(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable String claimId,
+            @RequestBody @Valid SellerOrderClaimProcessRequest request) {
+
+        sellerService.processOrderClaim(userDetails.getUsername(), UUID.fromString(claimId), request);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/multicampus/gamesungcoding/a11ymarketserver/feature/seller/model/SellerOrderClaimProcessRequest.java
+++ b/src/main/java/com/multicampus/gamesungcoding/a11ymarketserver/feature/seller/model/SellerOrderClaimProcessRequest.java
@@ -1,0 +1,7 @@
+package com.multicampus.gamesungcoding.a11ymarketserver.feature.seller.model;
+
+import jakarta.validation.constraints.NotNull;
+
+public record SellerOrderClaimProcessRequest(
+        @NotNull String action) {
+}


### PR DESCRIPTION
## PR 내용

- 취소/반품/교환 처리 기능 추가

## 연관 이슈

Resolves #44 

## 변경 사항

- [x] OrderItems (Entity)
ㄴ updateOrderItemStatus(OrderItemStatus status) 메서드 추가

- [x] SellerOrderClaimProcessRequest (DTO)
ㄴ @NotNull String action 필드 정의

- [x] SellerService
ㄴ processOrderClaim(String userEmail, UUID orderItemId, SellerOrderClaimProcessRequest request) 메서드 추가

- [x] SellerController
ㄴ POST /api/v1/seller/claims/{claimId}/approve 엔드포인트 추가

## 리뷰 요구사항(Optional)

전체적으로 검토 및 어색하거나 맞지 않는 코드가 있으면 수정 요청 부탁드립니다.