### PR TITLE
Feat: #45 add confirm order API

### DIFF
--- a/src/main/java/com/multicampus/gamesungcoding/a11ymarketserver/admin/order/service/AdminOrderService.java
+++ b/src/main/java/com/multicampus/gamesungcoding/a11ymarketserver/admin/order/service/AdminOrderService.java
@@ -40,7 +40,7 @@ public class AdminOrderService {
         Orders order = ordersRepository.findById(orderId)
                 .orElseThrow(() -> new DataNotFoundException("Order not found"));
 
-        List<OrderItems> items = orderItemsRepository.findByOrderId(orderId);
+        List<OrderItems> items = orderItemsRepository.findAllByOrderId(orderId);
 
         return ResponseEntity.ok(OrderDetailResponse.fromEntity(order, items));
     }
@@ -51,7 +51,7 @@ public class AdminOrderService {
                 .orElseThrow(() -> new DataNotFoundException("Order not found"));
 
         OrderStatus newStatus;
-        
+
         try {
             newStatus = OrderStatus.valueOf(status.toUpperCase());
         } catch (IllegalArgumentException e) {

--- a/src/main/java/com/multicampus/gamesungcoding/a11ymarketserver/feature/order/controller/OrderController.java
+++ b/src/main/java/com/multicampus/gamesungcoding/a11ymarketserver/feature/order/controller/OrderController.java
@@ -77,4 +77,14 @@ public class OrderController {
 
         orderService.cancelOrderItems(userDetails.getUsername(), UUID.fromString(orderId), req);
     }
+
+    // 주문 확정
+    @PostMapping("v1/users/me/orders/{orderId}/confirm")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void confirmOrderItems(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable String orderId,
+            @RequestBody @Valid OrderConfirmRequest req) {
+        orderService.confirmOrderItems(userDetails.getUsername(), orderId, req);
+    }
 }

--- a/src/main/java/com/multicampus/gamesungcoding/a11ymarketserver/feature/order/dto/OrderConfirmRequest.java
+++ b/src/main/java/com/multicampus/gamesungcoding/a11ymarketserver/feature/order/dto/OrderConfirmRequest.java
@@ -1,0 +1,8 @@
+package com.multicampus.gamesungcoding.a11ymarketserver.feature.order.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+
+public record OrderConfirmRequest(
+        @NotEmpty(message = "구매 확정할 상품을 선택해주세요.") String orderItemId
+) {
+}

--- a/src/main/java/com/multicampus/gamesungcoding/a11ymarketserver/feature/order/repository/OrderItemsRepository.java
+++ b/src/main/java/com/multicampus/gamesungcoding/a11ymarketserver/feature/order/repository/OrderItemsRepository.java
@@ -12,7 +12,7 @@ import java.util.UUID;
 
 public interface OrderItemsRepository extends JpaRepository<OrderItems, UUID> {
     // 특정 orderId 주문의 모든 상품 조회
-    List<OrderItems> findByOrderId(UUID orderId);
+    List<OrderItems> findAllByOrderId(UUID orderId);
 
     @Query("""
             SELECT new com.multicampus.gamesungcoding.a11ymarketserver.feature.seller.model.SellerOrderItemResponse(o, oi)


### PR DESCRIPTION
## PR 내용
- 구매 확정 요청 API 구현

기능 ID: REQ-84

## 연관 이슈
Resolves #45 

## 변경 사항
- [x] OrderConfirmReqeust DTO 생성
- [x] OrderService : 검증 로직, OrderItem 상태를 COMFRIMED로 변경 처리
모든 아이템이 확정된 경우 Order의 상태 -> DELIVERED
- [x] OrderController에 ("v1/users/me/orders/{orderId}/confirm") PostMapping